### PR TITLE
Don't map/unmap a buffer so often.

### DIFF
--- a/Pod/Pod.xcodeproj/project.pbxproj
+++ b/Pod/Pod.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		146D728B1AB782920058798C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = Example;
 				TargetAttributes = {

--- a/Source/HYPSignatureView.h
+++ b/Source/HYPSignatureView.h
@@ -1,9 +1,32 @@
 @import UIKit;
 @import GLKit;
 
+/**
+ * The default stroke width minimum.
+ * @see strokeWidthMin
+ */
+extern CGFloat const kHYPSignatureDefaultStrokeWidthMin;
+/**
+ * The default stroke width maximum.
+ * @see strokeWidthMax
+ */
+extern CGFloat const kHYPSignatureDefaultStrokeWidthMax;
+
+
 @interface HYPSignatureView : GLKView
 
 @property (nonatomic) UIColor *strokeColor;
+/**
+ * The minimum stroke width (line thickness).
+ * The width is determined by touch velocity, so this is the minimum width for the dynamic range.
+ */
+@property (nonatomic, assign) CGFloat strokeWidthMin;
+/**
+ * The maximum stroke width (line thickness).
+ * The width is determined by touch velocity, so this is the maximum width for the dynamic range.
+ */
+@property (nonatomic, assign) CGFloat strokeWidthMax;
+
 @property (nonatomic, readonly) BOOL hasSignature;
 
 - (void)erase;

--- a/Source/HYPSignatureView.m
+++ b/Source/HYPSignatureView.m
@@ -394,6 +394,7 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
         }
     }
 
+    unmapVertexBuffer(mappedBuffer);
     [self setNeedsDisplay];
 }
 

--- a/Source/HYPSignatureView.m
+++ b/Source/HYPSignatureView.m
@@ -115,13 +115,24 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 @implementation HYPSignatureView
 
 - (id)initWithFrame:(CGRect)frame {
-    self = [super initWithFrame:frame];
-    if (!self) return nil;
+    if ((self = [super initWithFrame:frame])) {
+        [self setup];
+    }
+    
+    return self;
+}
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    if ((self = [super initWithCoder:aDecoder])) {
+        [self setup];
+    }
+    return self;
+}
+
+- (void)setup {
     context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
     if (!context) {
         [NSException raise:@"NSOpenGLES2ContextException" format:@"Failed to create OpenGL ES2 context"];
-        return nil;
     }
 
     time(NULL);
@@ -141,7 +152,7 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     self.drawableMultisample = GLKViewDrawableMultisample4X;
 
     [self setupGL];
-
+    
     // Capture touches
     UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(pan:)];
     pan.maximumNumberOfTouches = pan.minimumNumberOfTouches = 1;
@@ -157,8 +168,6 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     UILongPressGestureRecognizer *longer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
     longer.cancelsTouchesInView = YES;
     [self addGestureRecognizer:longer];
-
-    return self;
 }
 
 

--- a/Source/HYPSignatureView.m
+++ b/Source/HYPSignatureView.m
@@ -26,21 +26,20 @@ typedef struct HYPSignaturePoint HYPSignaturePoint;
 // Maximum verteces in signature
 static const int maxLength = MAXIMUM_VERTECES;
 
-
 static inline GLvoid *mapVertexBuffer(GLuint bufferToMap, NSError **error) {
     glBindBuffer(GL_ARRAY_BUFFER, bufferToMap);
-
+    
     GLvoid *data = glMapBufferOES(GL_ARRAY_BUFFER, GL_WRITE_ONLY_OES);
-
+    
     if (data == NULL && error != NULL) {
         GLenum glError = glGetError();
-
+        
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
         userInfo[@"GL_ERROR"] = @(glError);
-
+        
         *error = [NSError errorWithDomain:NSStringFromClass(HYPSignatureView.class) code:ERROR_OPENGL userInfo:userInfo];
     }
-
+    
     return data;
 }
 
@@ -49,7 +48,7 @@ static inline void addVertex(GLvoid *mappedBuffer, uint *length, HYPSignaturePoi
     if ((*length) >= maxLength) {
         return;
     }
-
+    
     memcpy(mappedBuffer + sizeof(HYPSignaturePoint) * (*length), &vertex, sizeof(HYPSignaturePoint));
     (*length)++;
 }
@@ -57,13 +56,13 @@ static inline void addVertex(GLvoid *mappedBuffer, uint *length, HYPSignaturePoi
 static inline void unmapVertexBuffer(GLuint *mappedBuffer) {
     if (mappedBuffer != NULL) {
         GLboolean result = glUnmapBufferOES(GL_ARRAY_BUFFER);
-
+        
         if (result == GL_FALSE) {
             // GL docs say this indicates some kind of corruption, and the buffer should be reinitialized.
             // TODO: Reinitialize the buffer
         }
     }
-
+    
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
@@ -71,7 +70,7 @@ static inline CGPoint QuadraticPointInCurve(CGPoint start, CGPoint end, CGPoint 
     double a = pow((1.0 - percent), 2.0);
     double b = 2.0 * percent * (1.0 - percent);
     double c = pow(percent, 2.0);
-
+    
     return (CGPoint) {
         a * start.x + b * controlPoint.x + c * end.x,
         a * start.y + b * controlPoint.y + c * end.y
@@ -92,7 +91,7 @@ static GLKVector3 perpendicular(HYPSignaturePoint p1, HYPSignaturePoint p2) {
 }
 
 static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVector3 color) {
-
+    
     return (HYPSignaturePoint) {
         {
             (viewPoint.x / bounds.size.width * 2.0 - 1),
@@ -108,26 +107,26 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     // OpenGL state
     EAGLContext *context;
     GLKBaseEffect *effect;
-
+    
     GLuint vertexArray;
     GLuint vertexBuffer;
     GLuint dotsArray;
     GLuint dotsBuffer;
-
-
-    // Array of verteces, with current length
+    
+    
+    // Array of vertices, with current length
     HYPSignaturePoint SignatureVertexData[maxLength];
     uint length;
-
+    
     HYPSignaturePoint SignatureDotsData[maxLength];
     uint dotsLength;
-
-
+    
+    
     // Width of line at current and previous vertex
     float penThickness;
     float previousThickness;
-
-
+    
+    
     // Previous points for quadratic bezier computations
     CGPoint previousPoint;
     CGPoint previousMidPoint;
@@ -162,23 +161,23 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     if (!context) {
         [NSException raise:@"NSOpenGLES2ContextException" format:@"Failed to create OpenGL ES2 context"];
     }
-
+    
     time(NULL);
-
+    
     //Defaults
     self.backgroundColor = [UIColor whiteColor];
     self.opaque = NO;
-
+    
     self.context = context;
     self.drawableDepthFormat = GLKViewDrawableDepthFormat24;
     self.enableSetNeedsDisplay = YES;
-
+    
     self.strokeWidthMin = kHYPSignatureDefaultStrokeWidthMin;
     self.strokeWidthMax = kHYPSignatureDefaultStrokeWidthMax;
     
     // Turn on antialiasing
     self.drawableMultisample = GLKViewDrawableMultisample4X;
-
+    
     [self setupGL];
     
     // Capture touches
@@ -186,12 +185,12 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     pan.maximumNumberOfTouches = pan.minimumNumberOfTouches = 1;
     pan.cancelsTouchesInView = YES;
     [self addGestureRecognizer:pan];
-
+    
     // For dotting your i's
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
     tap.cancelsTouchesInView = YES;
     [self addGestureRecognizer:tap];
-
+    
     // Erase with long press
     UILongPressGestureRecognizer *longer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
     longer.cancelsTouchesInView = YES;
@@ -201,11 +200,11 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)dealloc {
     [self tearDownGL];
-
+    
     if ([EAGLContext currentContext] == context) {
         [EAGLContext setCurrentContext:nil];
     }
-
+    
     context = nil;
 }
 
@@ -213,15 +212,15 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 - (void)drawRect:(CGRect)rect {
     glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
     glClear(GL_COLOR_BUFFER_BIT);
-
+    
     [effect prepareToDraw];
-
+    
     // Drawing of signature lines
     if (length > 2) {
         glBindVertexArrayOES(vertexArray);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, length);
     }
-
+    
     if (dotsLength > 0) {
         glBindVertexArrayOES(dotsArray);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, dotsLength);
@@ -246,7 +245,7 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     length = 0;
     dotsLength = 0;
     self.hasSignature = NO;
-
+    
     [self setNeedsDisplay];
 }
 
@@ -259,47 +258,47 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)tap:(UITapGestureRecognizer *)tap {
     CGPoint l = [tap locationInView:self];
-
+    
     if (tap.state == UIGestureRecognizerStateRecognized) {
         __autoreleasing NSError *error = nil;
         GLuint *mappedBuffer = mapVertexBuffer(dotsBuffer, &error);
-
+        
         if (mappedBuffer == NULL) {
             // TODO: Handle the error condition
         } else {
-			HYPSignaturePoint touchPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
+            HYPSignaturePoint touchPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
             addVertex(mappedBuffer, &dotsLength, touchPoint);
-
-			HYPSignaturePoint centerPoint = touchPoint;
-			centerPoint.color = StrokeColor;
+            
+            HYPSignaturePoint centerPoint = touchPoint;
+            centerPoint.color = StrokeColor;
             addVertex(mappedBuffer, &dotsLength, centerPoint);
-
-			static int segments = 20;
-			GLKVector2 radius = (GLKVector2){
-				clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5)),
-				clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5))
-			};
-			GLKVector2 velocityRadius = radius;
-			float angle = 0;
-
-			for (int i = 0; i <= segments; i++) {
-
-				HYPSignaturePoint p = centerPoint;
-				p.vertex.x += velocityRadius.x * cosf(angle);
-				p.vertex.y += velocityRadius.y * sinf(angle);
-
+            
+            static int segments = 20;
+            GLKVector2 radius = (GLKVector2) {
+                clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5)),
+                clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5))
+            };
+            GLKVector2 velocityRadius = radius;
+            float angle = 0;
+            
+            for (int i = 0; i <= segments; i++) {
+                
+                HYPSignaturePoint p = centerPoint;
+                p.vertex.x += velocityRadius.x * cosf(angle);
+                p.vertex.y += velocityRadius.y * sinf(angle);
+                
                 addVertex(mappedBuffer, &dotsLength, p);
                 addVertex(mappedBuffer, &dotsLength, centerPoint);
-
-				angle += M_PI * 2.0 / segments;
-			}
-
+                
+                angle += M_PI * 2.0 / segments;
+            }
+            
             addVertex(mappedBuffer, &dotsLength, touchPoint);
-		}
-
-		unmapVertexBuffer(mappedBuffer);
-	}
-
+        }
+        
+        unmapVertexBuffer(mappedBuffer);
+    }
+    
     [self setNeedsDisplay];
 }
 
@@ -309,92 +308,93 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 }
 
 - (void)pan:(UIPanGestureRecognizer *)pan {
-
+    
     NSError *error;
     GLuint *mappedBuffer = mapVertexBuffer(vertexBuffer, &error);
-
+    
     if (mappedBuffer == NULL) {
         // TODO(rgrimm): Handle the error condition
     } else {
-
-    CGPoint velocity = [pan velocityInView:self];
-    CGPoint location = [pan locationInView:self];
-
+        
+        CGPoint velocity = [pan velocityInView:self];
+        CGPoint location = [pan locationInView:self];
+        
         currentVelocity = ViewPointToGL(velocity, self.bounds, (GLKVector3) {0, 0, 0});
         float distance = 0.;
         if (previousPoint.x > 0) {
             distance = sqrtf((location.x - previousPoint.x) * (location.x - previousPoint.x) + (location.y - previousPoint.y) * (location.y - previousPoint.y));
         }
-
+        
         float velocityMagnitude = sqrtf(velocity.x * velocity.x + velocity.y * velocity.y);
         float clampedVelocityMagnitude = clamp(VELOCITY_CLAMP_MIN, VELOCITY_CLAMP_MAX, velocityMagnitude);
         float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
-
-    float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
-    float newThickness = (self.strokeWidthMax - self.strokeWidthMin) * (1 - normalizedVelocity) + self.strokeWidthMin;
-    penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
-
-    if ([pan state] == UIGestureRecognizerStateBegan) {
-
-        previousPoint = location;
-        previousMidPoint = location;
-
-        HYPSignaturePoint startPoint = ViewPointToGL(location, self.bounds, (GLKVector3){1, 1, 1});
-        previousVertex = startPoint;
-        previousThickness = penThickness;
-
+        
+        float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
+        float newThickness = (self.strokeWidthMax - self.strokeWidthMin) * (1 - normalizedVelocity) + self.strokeWidthMin;
+        penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
+        
+        if ([pan state] == UIGestureRecognizerStateBegan) {
+            
+            previousPoint = location;
+            previousMidPoint = location;
+            
+            HYPSignaturePoint startPoint = ViewPointToGL(location, self.bounds, (GLKVector3){1, 1, 1});
+            previousVertex = startPoint;
+            previousThickness = penThickness;
+            
             addVertex(mappedBuffer, &length, startPoint);
             addVertex(mappedBuffer, &length, previousVertex);
-
-        self.hasSignature = YES;
-
-    } else if ([pan state] == UIGestureRecognizerStateChanged) {
-
-        CGPoint mid = CGPointMake((location.x + previousPoint.x) / 2.0, (location.y + previousPoint.y) / 2.0);
-
-        if (distance > QUADRATIC_DISTANCE_TOLERANCE) {
-            // Plot quadratic bezier instead of line
-            unsigned int i;
-
-            int segments = (int) distance / 1.5;
-
-            float startPenThickness = previousThickness;
-            float endPenThickness = penThickness;
-            previousThickness = penThickness;
-
+            
+            self.hasSignature = YES;
+            
+        } else if ([pan state] == UIGestureRecognizerStateChanged) {
+            
+            CGPoint mid = CGPointMake((location.x + previousPoint.x) / 2.0, (location.y + previousPoint.y) / 2.0);
+            
+            if (distance > QUADRATIC_DISTANCE_TOLERANCE) {
+                // Plot quadratic bezier instead of line
+                unsigned int i;
+                
+                int segments = (int) distance / 1.5;
+                
+                float startPenThickness = previousThickness;
+                float endPenThickness = penThickness;
+                previousThickness = penThickness;
+                
                 for (i = 0; i < segments; i++) {
                     penThickness = startPenThickness + ((endPenThickness - startPenThickness) / segments) * i;
-
-                CGPoint quadPoint = QuadraticPointInCurve(previousMidPoint, mid, previousPoint, (float)i / (float)(segments));
-
+                    
+                    CGPoint quadPoint = QuadraticPointInCurve(previousMidPoint, mid, previousPoint, (float)i / (float)(segments));
+                    
                     HYPSignaturePoint vertex = ViewPointToGL(quadPoint, self.bounds, StrokeColor);
                     [self addTriangleStripPointsInMappedBuffer:mappedBuffer previous:previousVertex next:vertex];
-
-                previousVertex = vertex;
-            }
-        } else if (distance > 1.0) {
-
+                    
+                    previousVertex = vertex;
+                }
+            } else if (distance > 1.0) {
+                
                 HYPSignaturePoint vertex = ViewPointToGL(location, self.bounds, StrokeColor);
                 [self addTriangleStripPointsInMappedBuffer:mappedBuffer previous:previousVertex next:vertex];
-
-            previousVertex = vertex;
-            previousThickness = penThickness;
-        }
-
-        previousPoint = location;
-        previousMidPoint = mid;
-
-    } else if (pan.state == UIGestureRecognizerStateEnded | pan.state == UIGestureRecognizerStateCancelled) {
-
-        HYPSignaturePoint vertex = ViewPointToGL(location, self.bounds, (GLKVector3){1, 1, 1});
+                
+                previousVertex = vertex;
+                previousThickness = penThickness;
+            }
+            
+            previousPoint = location;
+            previousMidPoint = mid;
+            
+        } else if (pan.state == UIGestureRecognizerStateEnded | pan.state == UIGestureRecognizerStateCancelled) {
+            
+            HYPSignaturePoint vertex = ViewPointToGL(location, self.bounds, (GLKVector3){1, 1, 1});
             addVertex(mappedBuffer, &length, vertex);
-
+            
             previousVertex = vertex;
             addVertex(mappedBuffer, &length, previousVertex);
         }
     }
-
+    
     unmapVertexBuffer(mappedBuffer);
+    
     [self setNeedsDisplay];
 }
 
@@ -419,7 +419,7 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
     [super setBackgroundColor:backgroundColor];
-
+    
     CGFloat red, green, blue, alpha, white;
     if ([backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha]) {
         clearColor[0] = red;
@@ -439,44 +439,44 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)setupGL {
     [EAGLContext setCurrentContext:context];
-
+    
     effect = [[GLKBaseEffect alloc] init];
-
+    
     [self updateStrokeColor];
-
-
+    
+    
     glDisable(GL_DEPTH_TEST);
-
+    
     // Signature Lines
     glGenVertexArraysOES(1, &vertexArray);
     glBindVertexArrayOES(vertexArray);
-
+    
     glGenBuffers(1, &vertexBuffer);
     glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
     glBufferData(GL_ARRAY_BUFFER, sizeof(SignatureVertexData), SignatureVertexData, GL_DYNAMIC_DRAW);
     [self bindShaderAttributes];
-
-
+    
+    
     // Signature Dots
     glGenVertexArraysOES(1, &dotsArray);
     glBindVertexArrayOES(dotsArray);
-
+    
     glGenBuffers(1, &dotsBuffer);
     glBindBuffer(GL_ARRAY_BUFFER, dotsBuffer);
     glBufferData(GL_ARRAY_BUFFER, sizeof(SignatureDotsData), SignatureDotsData, GL_DYNAMIC_DRAW);
     [self bindShaderAttributes];
-
-
+    
+    
     glBindVertexArrayOES(0);
-
-
+    
+    
     // Perspective
     GLKMatrix4 ortho = GLKMatrix4MakeOrtho(-1, 1, -1, 1, 0.1f, 2.0f);
     effect.transform.projectionMatrix = ortho;
-
+    
     GLKMatrix4 modelViewMatrix = GLKMatrix4MakeTranslation(0.0f, 0.0f, -1.0f);
     effect.transform.modelviewMatrix = modelViewMatrix;
-
+    
     length = 0;
     penThickness = 0.003;
     previousPoint = CGPointMake(-100, -100);
@@ -510,13 +510,13 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)tearDownGL {
     [EAGLContext setCurrentContext:context];
-
+    
     glDeleteVertexArraysOES(1, &vertexArray);
     glDeleteBuffers(1, &vertexBuffer);
-
+    
     glDeleteVertexArraysOES(1, &dotsArray);
     glDeleteBuffers(1, &dotsBuffer);
-
+    
     effect = nil;
 }
 

--- a/Source/HYPSignatureView.m
+++ b/Source/HYPSignatureView.m
@@ -38,7 +38,7 @@ static inline GLvoid *mapVertexBuffer(GLuint bufferToMap, NSError **error) {
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
         userInfo[@"GL_ERROR"] = @(glError);
 
-        *error = [[NSError alloc] initWithDomain:NSStringFromClass(HYPSignatureView.class) code:ERROR_OPENGL userInfo:userInfo];
+        *error = [NSError errorWithDomain:NSStringFromClass(HYPSignatureView.class) code:ERROR_OPENGL userInfo:userInfo];
     }
 
     return data;

--- a/Source/HYPSignatureView.m
+++ b/Source/HYPSignatureView.m
@@ -309,11 +309,11 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)pan:(UIPanGestureRecognizer *)pan {
     
-    NSError *error;
+    __autoreleasing NSError *error;
     GLuint *mappedBuffer = mapVertexBuffer(vertexBuffer, &error);
     
     if (mappedBuffer == NULL) {
-        // TODO(rgrimm): Handle the error condition
+        // TODO: Handle the error condition
     } else {
         
         CGPoint velocity = [pan velocityInView:self];

--- a/Source/HYPSignatureView.m
+++ b/Source/HYPSignatureView.m
@@ -2,6 +2,7 @@
 
 #import <OpenGLES/ES2/glext.h>
 
+#define ERROR_OPENGL 1
 #define MAXIMUM_VERTECES 100000
 #define QUADRATIC_DISTANCE_TOLERANCE 3.0 // Minimum distance to make a curve
 #define STROKE_WIDTH_MAX 0.010
@@ -25,17 +26,44 @@ typedef struct HYPSignaturePoint HYPSignaturePoint;
 static const int maxLength = MAXIMUM_VERTECES;
 
 
+static inline GLvoid *mapVertexBuffer(GLuint bufferToMap, NSError **error) {
+    glBindBuffer(GL_ARRAY_BUFFER, bufferToMap);
+
+    GLvoid *data = glMapBufferOES(GL_ARRAY_BUFFER, GL_WRITE_ONLY_OES);
+
+    if (data == NULL && error != NULL) {
+        GLenum glError = glGetError();
+
+        NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+        userInfo[@"GL_ERROR"] = @(glError);
+
+        *error = [[NSError alloc] initWithDomain:NSStringFromClass(HYPSignatureView.class) code:ERROR_OPENGL userInfo:userInfo];
+    }
+
+    return data;
+}
+
 // Append vertex to array buffer
-static inline void addVertex(uint *length, HYPSignaturePoint v) {
+static inline void addVertex(GLvoid *mappedBuffer, uint *length, HYPSignaturePoint vertex) {
     if ((*length) >= maxLength) {
         return;
     }
 
-    GLvoid *data = glMapBufferOES(GL_ARRAY_BUFFER, GL_WRITE_ONLY_OES);
-    memcpy(data + sizeof(HYPSignaturePoint) * (*length), &v, sizeof(HYPSignaturePoint));
-    glUnmapBufferOES(GL_ARRAY_BUFFER);
-
+    memcpy(mappedBuffer + sizeof(HYPSignaturePoint) * (*length), &vertex, sizeof(HYPSignaturePoint));
     (*length)++;
+}
+
+static inline void unmapVertexBuffer(GLuint *mappedBuffer) {
+    if (mappedBuffer != NULL) {
+        GLboolean result = glUnmapBufferOES(GL_ARRAY_BUFFER);
+
+        if (result == GL_FALSE) {
+            // GL docs say this indicates some kind of corruption, and the buffer should be reinitialized.
+            // TODO: Reinitialize the buffer
+        }
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 static inline CGPoint QuadraticPointInCurve(CGPoint start, CGPoint end, CGPoint controlPoint, float percent) {
@@ -206,39 +234,44 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     CGPoint l = [tap locationInView:self];
 
     if (tap.state == UIGestureRecognizerStateRecognized) {
-        glBindBuffer(GL_ARRAY_BUFFER, dotsBuffer);
+        __autoreleasing NSError *error = nil;
+        GLuint *mappedBuffer = mapVertexBuffer(dotsBuffer, &error);
 
-        HYPSignaturePoint touchPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
-        addVertex(&dotsLength, touchPoint);
+        if (mappedBuffer == NULL) {
+            // TODO: Handle the error condition
+        } else {
+			HYPSignaturePoint touchPoint = ViewPointToGL(l, self.bounds, (GLKVector3){1, 1, 1});
+            addVertex(mappedBuffer, &dotsLength, touchPoint);
 
-        HYPSignaturePoint centerPoint = touchPoint;
-        centerPoint.color = StrokeColor;
-        addVertex(&dotsLength, centerPoint);
+			HYPSignaturePoint centerPoint = touchPoint;
+			centerPoint.color = StrokeColor;
+            addVertex(mappedBuffer, &dotsLength, centerPoint);
 
-        static int segments = 20;
-        GLKVector2 radius = (GLKVector2){
-            clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5)),
-            clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5))
-        };
-        GLKVector2 velocityRadius = radius;
-        float angle = 0;
+			static int segments = 20;
+			GLKVector2 radius = (GLKVector2){
+				clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5)),
+				clamp(0.00001, 0.02, penThickness * generateRandom(0.5, 1.5))
+			};
+			GLKVector2 velocityRadius = radius;
+			float angle = 0;
 
-        for (int i = 0; i <= segments; i++) {
+			for (int i = 0; i <= segments; i++) {
 
-            HYPSignaturePoint p = centerPoint;
-            p.vertex.x += velocityRadius.x * cosf(angle);
-            p.vertex.y += velocityRadius.y * sinf(angle);
+				HYPSignaturePoint p = centerPoint;
+				p.vertex.x += velocityRadius.x * cosf(angle);
+				p.vertex.y += velocityRadius.y * sinf(angle);
 
-            addVertex(&dotsLength, p);
-            addVertex(&dotsLength, centerPoint);
+                addVertex(mappedBuffer, &dotsLength, p);
+                addVertex(mappedBuffer, &dotsLength, centerPoint);
 
-            angle += M_PI * 2.0 / segments;
-        }
+				angle += M_PI * 2.0 / segments;
+			}
 
-        addVertex(&dotsLength, touchPoint);
+            addVertex(mappedBuffer, &dotsLength, touchPoint);
+		}
 
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-    }
+		unmapVertexBuffer(mappedBuffer);
+	}
 
     [self setNeedsDisplay];
 }
@@ -250,24 +283,29 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)pan:(UIPanGestureRecognizer *)pan {
 
-    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    NSError *error;
+    GLuint *mappedBuffer = mapVertexBuffer(vertexBuffer, &error);
+
+    if (mappedBuffer == NULL) {
+        // TODO(rgrimm): Handle the error condition
+    } else {
 
     CGPoint velocity = [pan velocityInView:self];
     CGPoint location = [pan locationInView:self];
 
-    currentVelocity = ViewPointToGL(velocity, self.bounds, (GLKVector3){0,0,0});
-    float distance = 0.;
-    if (previousPoint.x > 0) {
-        distance = sqrtf((location.x - previousPoint.x) * (location.x - previousPoint.x) + (location.y - previousPoint.y) * (location.y - previousPoint.y));
-    }
+        currentVelocity = ViewPointToGL(velocity, self.bounds, (GLKVector3) {0, 0, 0});
+        float distance = 0.;
+        if (previousPoint.x > 0) {
+            distance = sqrtf((location.x - previousPoint.x) * (location.x - previousPoint.x) + (location.y - previousPoint.y) * (location.y - previousPoint.y));
+        }
 
-    float velocityMagnitude = sqrtf(velocity.x*velocity.x + velocity.y*velocity.y);
-    float clampedVelocityMagnitude = clamp(VELOCITY_CLAMP_MIN, VELOCITY_CLAMP_MAX, velocityMagnitude);
-    float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
+        float velocityMagnitude = sqrtf(velocity.x * velocity.x + velocity.y * velocity.y);
+        float clampedVelocityMagnitude = clamp(VELOCITY_CLAMP_MIN, VELOCITY_CLAMP_MAX, velocityMagnitude);
+        float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
 
-    float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
-    float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
-    penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
+        float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
+        float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
+        penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
 
     if ([pan state] == UIGestureRecognizerStateBegan) {
 
@@ -278,8 +316,8 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
         previousVertex = startPoint;
         previousThickness = penThickness;
 
-        addVertex(&length, startPoint);
-        addVertex(&length, previousVertex);
+            addVertex(mappedBuffer, &length, startPoint);
+            addVertex(mappedBuffer, &length, previousVertex);
 
         self.hasSignature = YES;
 
@@ -297,23 +335,22 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
             float endPenThickness = penThickness;
             previousThickness = penThickness;
 
-            for (i = 0; i < segments; i++)
-            {
-                penThickness = startPenThickness + ((endPenThickness - startPenThickness) / segments) * i;
+                for (i = 0; i < segments; i++) {
+                    penThickness = startPenThickness + ((endPenThickness - startPenThickness) / segments) * i;
 
                 CGPoint quadPoint = QuadraticPointInCurve(previousMidPoint, mid, previousPoint, (float)i / (float)(segments));
 
-                HYPSignaturePoint v = ViewPointToGL(quadPoint, self.bounds, StrokeColor);
-                [self addTriangleStripPointsForPrevious:previousVertex next:v];
+                    HYPSignaturePoint vertex = ViewPointToGL(quadPoint, self.bounds, StrokeColor);
+                    [self addTriangleStripPointsInMappedBuffer:mappedBuffer previous:previousVertex next:vertex];
 
-                previousVertex = v;
+                previousVertex = vertex;
             }
         } else if (distance > 1.0) {
 
-            HYPSignaturePoint v = ViewPointToGL(location, self.bounds, StrokeColor);
-            [self addTriangleStripPointsForPrevious:previousVertex next:v];
+                HYPSignaturePoint vertex = ViewPointToGL(location, self.bounds, StrokeColor);
+                [self addTriangleStripPointsInMappedBuffer:mappedBuffer previous:previousVertex next:vertex];
 
-            previousVertex = v;
+            previousVertex = vertex;
             previousThickness = penThickness;
         }
 
@@ -322,11 +359,12 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
     } else if (pan.state == UIGestureRecognizerStateEnded | pan.state == UIGestureRecognizerStateCancelled) {
 
-        HYPSignaturePoint v = ViewPointToGL(location, self.bounds, (GLKVector3){1, 1, 1});
-        addVertex(&length, v);
+        HYPSignaturePoint vertex = ViewPointToGL(location, self.bounds, (GLKVector3){1, 1, 1});
+            addVertex(mappedBuffer, &length, vertex);
 
-        previousVertex = v;
-        addVertex(&length, previousVertex);
+            previousVertex = vertex;
+            addVertex(mappedBuffer, &length, previousVertex);
+        }
     }
 
     [self setNeedsDisplay];
@@ -416,28 +454,28 @@ static HYPSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     previousPoint = CGPointMake(-100, -100);
 }
 
-- (void)addTriangleStripPointsForPrevious:(HYPSignaturePoint)previous next:(HYPSignaturePoint)next {
+- (void)addTriangleStripPointsInMappedBuffer:(GLuint *)mappedBuffer previous:(HYPSignaturePoint)previous next:(HYPSignaturePoint)next {
     float toTravel = penThickness / 2.0;
-
+    
     for (int i = 0; i < 2; i++) {
         GLKVector3 p = perpendicular(previous, next);
         GLKVector3 p1 = next.vertex;
         GLKVector3 ref = GLKVector3Add(p1, p);
-
+        
         float distance = GLKVector3Distance(p1, ref);
         float difX = p1.x - ref.x;
         float difY = p1.y - ref.y;
         float ratio = -1.0 * (toTravel / distance);
-
+        
         difX = difX * ratio;
         difY = difY * ratio;
-
+        
         HYPSignaturePoint stripPoint = {
             { p1.x + difX, p1.y + difY, 0.0 },
             StrokeColor
         };
-        addVertex(&length, stripPoint);
-
+        addVertex(mappedBuffer, &length, stripPoint);
+        
         toTravel *= -1;
     }
 }


### PR DESCRIPTION
This improves performance and prevents an issue where attempting to draw after clearing could not recognize the touch.
Also lays some foundation work for error handling.

Based on work here https://github.com/rmgrimm/PPSSignatureView/commit/bfa03120db497acc2e7b73483489f7472b3118d0
